### PR TITLE
Update email regex to use Ruby stdlib

### DIFF
--- a/welcome.rb
+++ b/welcome.rb
@@ -3,6 +3,7 @@
 require "etc"
 require "tty-prompt"
 require "tty-screen"
+require "uri"
 
 def sep
   puts
@@ -128,7 +129,7 @@ puts
 
 if prompt.yes?("  would you like to forward your mail elsewhere?")
   forward_addr = prompt.ask("  where would you like to forward your mail to?") do |q|
-    q.validate(/\A\w+@\w+\.\w+\Z/)
+    q.validate(URI::MailTo::EMAIL_REGEXP)
     q.messages[:valid?] = "Invalid email address"
   end
 


### PR DESCRIPTION
When signing up, I found that it failed because the regex couldn't handle characters in my email e.g foo.bar@example.com

I then found out there was a stdlib regex for email addresses now part of Ruby, so this PR should fix it, and be futureproof